### PR TITLE
Missed updates for QuickStart 5.17

### DIFF
--- a/ci/defaults.json
+++ b/ci/defaults.json
@@ -6,7 +6,7 @@
     "ParameterValue": "vpc-ae07a6cb"
 }, {
     "ParameterKey": "DeepSecuritySubnet",
-    "ParameterValue": "t2.small"
+    "ParameterValue": "subnet-35413a42"
 }, {
     "ParameterKey": "DeepSecurityAdminName",
     "ParameterValue": "admin"

--- a/ci/defaults.json
+++ b/ci/defaults.json
@@ -1,1 +1,25 @@
-{}
+[{
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "mykey"
+}, {
+    "ParameterKey": "AWSVPC",
+    "ParameterValue": "vpc-ae07a6cb"
+}, {
+    "ParameterKey": "DeepSecuritySubnet",
+    "ParameterValue": "t2.small"
+}, {
+    "ParameterKey": "DeepSecurityAdminName",
+    "ParameterValue": "admin"
+}, {
+    "ParameterKey": "DeepSecurityAdminPass",
+    "ParameterValue": "$[taskcat_genpass_8A]"
+}, {
+    "ParameterKey": "DatabaseSubnet1",
+    "ParameterValue": "subnet-974239e0"
+}, {
+    "ParameterKey": "DatabaseSubnet2",
+    "ParameterValue": "subnet-5e26703b"
+}, {
+    "ParameterKey": "ProtectedInstances",
+    "ParameterValue": "1-100"
+}]

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -264,53 +264,53 @@ Mappings:
       BYOL: ami-0e6e7d7edacbff83a
   DSMSIZE:
     us-east-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-east-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-west-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-west-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ca-central-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-south-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-northeast-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-southeast-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-southeast-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-northeast-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-central-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-west-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-west-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-west-3:
-      PerHost: r4.xlarge
-      BYOL: r4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     sa-east-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-gov-west-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
   DSMDBMap:
     SQL:
       DbTypeString: Microsoft SQL Server

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.16: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.17: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.16: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.17: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.16: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.17: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.16: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.17: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS


### PR DESCRIPTION
There were some updates that were missing from the previous PR.
- Updated missed templates to version 5.17
- Use m5 as DSM default instance type for dsm-mp.template