### PR TITLE
Updating to v5.33 (DSM 20.0.174)

### DIFF
--- a/scripts/reactivate-manager.sh
+++ b/scripts/reactivate-manager.sh
@@ -5,7 +5,8 @@ dnsHostNamesOn=
 SID=`curl -k -H "Content-Type: application/json" -X POST "https://localhost:$3/rest/authentication/login/primary" -d '{"dsCredentials":{"userName":"'$1'","password":"'$2'"}}'`
 
 ## get public hostname from metadata
-public_hostname=$(curl -s http://169.254.169.254/latest/meta-data/public-hostname)
+TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"`
+public_hostname=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/public-hostname)
 echo -e "public hostname returned from meta-data endpoint was \"$public_hostname\"\n" > mgract.log
 
 if [ -z $public_hostname ]

--- a/templates/common/db/ds-db-abstract.template
+++ b/templates/common/db/ds-db-abstract.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template is an abstraction layer for choosing PostgreSQL,
+Description: 'v5.33: This template is an abstraction layer for choosing PostgreSQL,
   Oracle or MSSQL when deploying Deep Security Manager. (qs-1ngr590i4)'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-mssql-rds.template
+++ b/templates/common/db/ds-db-mssql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template deploys an MSSQL RDS Instance for Deep Security
+Description: 'v5.33: This template deploys an MSSQL RDS Instance for Deep Security
   Manager. (qs-1ngr590ij)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-oracle-rds.template
+++ b/templates/common/db/ds-db-oracle-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template deploys an Oracle RDS instance for Deep Security
+Description: 'v5.33: This template deploys an Oracle RDS instance for Deep Security
   Manager. (qs-1ngr590i9)'
 Parameters:
   DBIRDSInstanceSize:
@@ -8,25 +8,27 @@ Parameters:
     Description: Trend Micro Deep Security Database instance class
     Type: String
     AllowedValues:
-    - db.m5.medium
     - db.m5.large
     - db.m5.xlarge
     - db.m5.2xlarge
+    - db.m5.4xlarge
     - db.m4.large
     - db.m4.xlarge
     - db.m4.2xlarge
     - db.m4.4xlarge
-    - db.m3.medium
-    - db.m3.large
-    - db.m3.xlarge
-    - db.m3.2xlarge
-    - db.r3.large
-    - db.r3.xlarge
-    - db.r3.2xlarge
-    - db.r3.4xlarge
-    - db.r3.8xlarge
     - db.r4.large
     - db.r4.xlarge
+    - db.r4.2xlarge
+    - db.r4.4xlarge
+    - db.r5.large
+    - db.r5.xlarge
+    - db.r5.2xlarge
+    - db.r5.4xlarge
+    - db.t3.small
+    - db.t3.medium
+    - db.t3.large
+    - db.t3.xlarge
+    - db.t3.2xlarge
     ConstraintDescription: must select a valid database instance type.
   DBIStorageAllocation:
     Default: 10
@@ -94,12 +96,8 @@ Resources:
       DBName: !Ref DBPName
       AllocatedStorage: !Ref DBIStorageAllocation
       DBInstanceClass: !Ref DBIRDSInstanceSize
-      Engine:
-        !If
-        - RegionIsUsGovCloud
-        - oracle-se1
-        - oracle-se2
-      EngineVersion: 12.1.0.2.v17
+      Engine: oracle-se2
+      EngineVersion: 19.0.0.0.ru-2020-04.rur-2020-04.r1
       MasterUsername: !Ref DBICAdminName
       MasterUserPassword: !Ref DBICAdminPassword
       VPCSecurityGroups:
@@ -113,10 +111,6 @@ Resources:
       - Key: Application
         Value: Deep Security Manager
 Conditions:
-  RegionIsUsGovCloud:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
   MultiAZ:
     !Equals
     - !Ref MultiAZ

--- a/templates/common/db/ds-db-postgresql-rds.template
+++ b/templates/common/db/ds-db-postgresql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template deploys a PostgreSQL RDS instance for Deep Security
+Description: 'v5.33: This template deploys a PostgreSQL RDS instance for Deep Security
   Manager. (qs-1ngr590ie)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/dsm-elb.template
+++ b/templates/common/dsm-elb.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: Deploys Elastic Load Balancers and Security Groups for Deep Security
+Description: 'v5.33: Deploys Elastic Load Balancers and Security Groups for Deep Security
   (qs-1ngr590je). Manager.'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/ds-elb-sg.template
+++ b/templates/common/security-groups/ds-elb-sg.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template creates security groups for the ELB for Deep Security
+Description: 'v5.33: This template creates security groups for the ELB for Deep Security
   Manager. (qs-1ngr590io)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-security-group.template
+++ b/templates/common/security-groups/dsm-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template creates the security group to allow inbound communication
+Description: 'v5.33: This template creates the security group to allow inbound communication
   to Deep Security Manager. (qs-1ngr590iu)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-sg-ingress-rules.template
+++ b/templates/common/security-groups/dsm-sg-ingress-rules.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template creates the ingress rules for Deep Security Managers.
+Description: 'v5.33: This template creates the ingress rules for Deep Security Managers.
   (qs-1ngr590j4)'
 Parameters:
   DSMSG:

--- a/templates/common/security-groups/rds-security-group.template
+++ b/templates/common/security-groups/rds-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: This template creates the security group to allow communication
+Description: 'v5.33: This template creates the security group to allow communication
   from Deep Security Managers to their RDS Instance. (qs-1ngr590j9)'
 Parameters:
   AWSIVPC:

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.33: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'
@@ -69,10 +69,12 @@ Parameters:
     - m4.xlarge
     - m4.2xlarge
     - m4.4xlarge
+    - m4.10xlarge
     - m5.large
     - m5.xlarge
     - m5.2xlarge
     - m5.4xlarge
+    - m5.8xlarge
     - c3.xlarge
     - c3.2xlarge
     - c3.4xlarge
@@ -81,6 +83,8 @@ Parameters:
     - c4.2xlarge
     - c4.4xlarge
     - c4.8xlarge
+    - c5.4xlarge
+    - c5.9xlarge
     - r3.large
     - r3.xlarge
     - r3.2xlarge
@@ -218,62 +222,62 @@ Parameters:
 Mappings:
   DSMAMI:
     ap-northeast-1:
-      PerHost: ami-0b25d1b6668ece3b6
-      BYOL: ami-01266ddf117fb8321
+      PerHost: ami-0a2f354157a87d729
+      BYOL: ami-0e302336b7682636c
     ap-northeast-2:
-      PerHost: ami-09fd0839c99eca15f
-      BYOL: ami-070b872829c013de9
+      PerHost: ami-0737f9d70fd4d04f3
+      BYOL: ami-00dc7d75798200cde
     ap-south-1:
-      PerHost: ami-087a9203ad68eab9b
-      BYOL: ami-02e2d939ffb896065
+      PerHost: ami-02346573fa15d1895
+      BYOL: ami-0455c38f09ac2e7a9
     ap-southeast-1:
-      PerHost: ami-07034c540a78e4a68
-      BYOL: ami-086585aa0063cc888
+      PerHost: ami-08a7a8e9f5fcf2d64
+      BYOL: ami-002d00b3b78c3a9a8
     ap-southeast-2:
-      PerHost: ami-0e1a3b9f764af7204
-      BYOL: ami-036ed91efe0eb2b50
+      PerHost: ami-03f7de9e950d4bf2a
+      BYOL: ami-0e446e51efeeeafb7
     ca-central-1:
-      PerHost: ami-0d8f7c5469be74dc4
-      BYOL: ami-0834a5f2a6661ef4a
-    eu-north-1:
-      PerHost: ami-0084375c54d7a3f8c
-      BYOL: ami-064a92bbb2901598e
+      PerHost: ami-0b0b98d56ba1a6179
+      BYOL: ami-0b41cf1a503fc30a7
     eu-central-1:
-      PerHost: ami-04df980f348dc36bc
-      BYOL: ami-0221930ec32159ff9
+      PerHost: ami-09ace5ec15cff1ffa
+      BYOL: ami-09d3948613e2ffff8
+    eu-north-1:
+      PerHost: ami-0ed4005889e30f39e
+      BYOL: ami-0eb99a8bab8388c10
     eu-west-1:
-      PerHost: ami-0bfbeac12e509d93e
-      BYOL: ami-0484ec24af8cd42d8
+      PerHost: ami-0add496ef8fa00500
+      BYOL: ami-01ff854c1877f9cac
     eu-west-2:
-      PerHost: ami-0e335b92acc072166
-      BYOL: ami-0f423f94c479816cf
+      PerHost: ami-0045c0ebfeba6291d
+      BYOL: ami-04252595ec7c5fdbf
     eu-west-3:
-      PerHost: ami-02f8a8df3c9e99c84
-      BYOL: ami-087e9dbc5b6a1b168
+      PerHost: ami-006736e5e126170c4
+      BYOL: ami-0ca7de52a6d488a76
+    me-south-1:
+      PerHost: ami-0327d5bbb787b81c0
+      BYOL: ami-0c3c491c917bef25f
     sa-east-1:
-      PerHost: ami-0d0886279d98a552a
-      BYOL: ami-04593be55dfad60e9
+      PerHost: ami-0568c1000df369296
+      BYOL: ami-0b742b23c16bf921f
     us-east-1:
-      PerHost: ami-0ac75de992838a10c
-      BYOL: ami-0e70f6cc7c38a7815
+      PerHost: ami-0b9a5613bf3c7a0ec
+      BYOL: ami-0b30361db90bbaeee
     us-east-2:
-      PerHost: ami-017796f62594f2a93
-      BYOL: ami-084d50b32481db320
-    us-gov-west-1:
-      PerHost: ami-a6320fc7
-      BYOL: ami-fa1a279b
-    us-west-1:
-      PerHost: ami-0a50bd481bbf51105
-      BYOL: ami-07b1109ee5bb048e9
-    us-west-2:
-      PerHost: ami-0556a6e419a35e363
-      BYOL: ami-041a7e695c4244c59
-    me-south-1 :
-      PerHost: ami-0ff44c44ddd3f80df
-      BYOL: ami-011785d9c069322fd
+      PerHost: ami-0bfb880ee8070f685
+      BYOL: ami-07a9ec1734911fe47
     us-gov-east-1:
-      PerHost: ami-c26d81b3
-      BYOL: ami-8317fbf2
+      PerHost: ami-00c7bda040bc80302
+      BYOL: ami-0959044160cc43bd9
+    us-gov-west-1:
+      PerHost: ami-001eef3040faa25c9
+      BYOL: ami-0de0e15763499eafa
+    us-west-1:
+      PerHost: ami-02eec3a1c2300bef3
+      BYOL: ami-02ebba1270401fdfe
+    us-west-2:
+      PerHost: ami-0037760aa99977a4b
+      BYOL: ami-0b70fcbe08f884715
   DSMSIZE:
     us-east-1:
       PerHost: m5.xlarge
@@ -449,6 +453,12 @@ Resources:
       Path: /
       Roles:
       - !Ref DSMRole
+  DSMLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        MetadataOptions:
+          HttpTokens: 'required'
   DSM:
     Type: AWS::EC2::Instance
     Metadata:
@@ -530,16 +540,16 @@ Resources:
                   AddressAndPortsScreen.HeartbeatPort=${DSIPHeartbeatPort}
                   ${NodeConfig}
                   SecurityUpdateScreen.UpdateComponents=true
-                  SecurityUpdateScreen.UpdateSoftware=true
+                  SoftwareUpdateScreen.UpdateSoftware=True
                   SmartProtectionNetworkScreen.EnableFeedback=false
                   SmartProtectionNetworkScreen.IndustryType=blank
                   RelayScreen.Install=True
-                  RelayScreen.ProxyType=None
-                  RelayScreen.ProxyPort=None
-                  RelayScreen.Proxy=False
-                  RelayScreen.AntiMalware=True
-                  RelayScreen.ProxyAuthentication=False
+                  ${softwareUpdateScreenProxyConfig}
+                  ${securityUpdateScreenProxyConfig}
                   Override.Automation=True
+                  Cloudformation.QSS3BucketName=${QSS3BucketName}
+                  Cloudformation.QSS3BucketRegion=${QSS3BucketRegion}
+                  Cloudformation.QSS3KeyPrefix=${QSS3KeyPrefix}
                 - LicenseConfig:
                     !If
                     - AddAcAnswer
@@ -560,14 +570,61 @@ Resources:
                     - |
                       AddressAndPortsScreen.NewNode=true
                       UpgradeVerificationScreen.Overwrite=False
+                  softwareUpdateScreenProxyConfig:
+                    !If
+                    - UseProxy
+                    - Fn::Sub:
+                      - |
+                        SoftwareUpdateScreen.Proxy=True
+                        SoftwareUpdateScreen.ProxyType=HTTP
+                        SoftwareUpdateScreen.ProxyAddress=${softwareUpdateScreenProxyHost}
+                        SoftwareUpdateScreen.ProxyPort=${softwareUpdateScreenProxyPort}
+                        SoftwareUpdateScreen.ProxyAuthentication="False"
+                        SoftwareUpdateScreen.ProxyUsername=""
+                        SoftwareUpdateScreen.ProxyPassword=""
+                      - softwareUpdateScreenProxyHost: !Select
+                        - 0
+                        - Fn::Split:
+                          - ":"
+                          - Fn::Sub: "${DSProxyUrl}"
+                        softwareUpdateScreenProxyPort: !Select
+                        - 1
+                        - Fn::Split:
+                          - ":"
+                          - Fn::Sub: "${DSProxyUrl}"
+                    - ''
+                  securityUpdateScreenProxyConfig:
+                    !If
+                    - UseProxy
+                    - Fn::Sub:
+                      - |
+                        SecurityUpdateScreen.Proxy=True
+                        SecurityUpdateScreen.ProxyType=HTTP
+                        SecurityUpdateScreen.ProxyAddress=${securityUpdateScreenProxyHost}
+                        SecurityUpdateScreen.ProxyPort=${securityUpdateScreenProxyPort}
+                        SecurityUpdateScreen.ProxyAuthentication="False"
+                        SecurityUpdateScreen.ProxyUsername=""
+                        SecurityUpdateScreen.ProxyPassword=""
+                      - securityUpdateScreenProxyHost: !Select
+                        - 0
+                        - Fn::Split:
+                          - ":"
+                          - Fn::Sub: "${DSProxyUrl}"
+                        securityUpdateScreenProxyPort: !Select
+                        - 1
+                        - Fn::Split:
+                          - ":"
+                          - Fn::Sub: "${DSProxyUrl}"
+                    - ''
               owner: root
               mode: '000600'
         installDSM:
           commands:
             0-sethostnameinprops:
-              command:
-                Fn::Sub: echo "AddressAndPortsScreen.ManagerAddress=$(curl http://169.254.169.254/latest/meta-data/local-ipv4/)"
-                  >> /etc/cfn/dsmConfiguration.properties
+              command: |
+                  TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"`
+                  managerAddress=`curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4/`
+                  echo "AddressAndPortsScreen.ManagerAddress=$managerAddress" >> /etc/cfn/dsmConfiguration.properties
               ignoreErrors: 'false'
             1-install-DSM:
               command: cd /opt/trend/packages/dsm/default/; sh /opt/trend/packages/dsm/default/ManagerAWS.sh
@@ -643,9 +700,9 @@ Resources:
           commands:
             0-add-instance-to-elb:
               command:
-                Fn::Sub: aws elb register-instances-with-load-balancer --load-balancer
-                  ${DSIELB} --instances $(curl http://169.254.169.254/latest/meta-data/instance-id/)
-                  --region ${AWS::Region}
+                Fn::Sub: |
+                  TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"`
+                  aws elb register-instances-with-load-balancer --load-balancer ${DSIELB} --instances $(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id/) --region ${AWS::Region}
               ignoreErrors: 'false'
         fixManagerLoadBalancerSettings:
           files:
@@ -680,8 +737,9 @@ Resources:
           commands:
             1-setHostsFileELB:
               command:
-                Fn::Sub: echo "$(curl http://169.254.169.254/latest/meta-data/local-ipv4/)
-                  ${DSIELBFQDN}" >> /etc/hosts
+                Fn::Sub: |
+                  TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"`
+                  echo "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4/) ${DSIELBFQDN}" >> /etc/hosts
         fixManagerHostObject:
           files:
             /etc/cfn/reactivate-manager.sh:
@@ -700,6 +758,9 @@ Resources:
                   ${DSCAdminName} ${DSCAdminPassword} ${DSIPGUIPort}
     Properties:
       IamInstanceProfile: !Ref DSMProfile
+      LaunchTemplate:
+          LaunchTemplateId: !Ref DSMLaunchTemplate
+          Version: '1'
       ImageId:
         !FindInMap
         - DSMAMI
@@ -744,7 +805,6 @@ Resources:
                   export HTTP_PROXY="http://${DSProxyUrl}"
                   export NO_PROXY="169.254.169.254,localhost,127.0.0.1"
                   echo -e "proxy=http://${DSProxyUrl}" >> /etc/yum.conf
-                  curl -ko /opt/trend/packages/dsm/default/Agent-amzn1-10.0.0-2240.x86_64.zip https://files.trendmicro.com/products/deepsecurity/en/10.0/Agent-amzn1-10.0.0-2240.x86_64.zip
               - ''
             ConfigSetOption1:
               !If

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.30: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.33: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:
@@ -265,10 +265,12 @@ Parameters:
     - m4.xlarge
     - m4.2xlarge
     - m4.4xlarge
+    - m4.10xlarge
     - m5.large
     - m5.xlarge
     - m5.2xlarge
     - m5.4xlarge
+    - m5.8xlarge
     - c3.xlarge
     - c3.2xlarge
     - c3.4xlarge
@@ -277,6 +279,8 @@ Parameters:
     - c4.2xlarge
     - c4.4xlarge
     - c4.8xlarge
+    - c5.4xlarge
+    - c5.9xlarge
     - r3.large
     - r3.xlarge
     - r3.2xlarge
@@ -354,6 +358,7 @@ Parameters:
   DSProxyUrl:
     Type: String
     Default: ''
+    AllowedPattern: '^$|^(?!(?i)http)(.+):[\d]+$|^(?=\d+\.\d+\.\d+\.\d+\:\d+$)(?:(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\.?){4}:(6553[0-5]|655[0-2][0-9]\d|65[0-4](\d){2}|6[0-4](\d){3}|[1-5](\d){4}|[1-9](\d){0,3}){1}$'
 Mappings:
   DSMNodeDependency:
     Node1DB:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.30: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.33: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.30: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.33: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS
@@ -140,98 +140,98 @@ Parameters:
 Mappings:
   DSMSIZE:
     us-east-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     us-west-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     us-west-2:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     eu-west-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     eu-central-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     sa-east-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     ap-northeast-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     ap-southeast-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     ap-southeast-2:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     ap-northeast-2:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     us-east-2:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     ca-central-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     ap-south-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     eu-north-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     eu-west-2:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     eu-west-3:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     us-gov-west-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     me-south-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
     us-gov-east-1:
-      '1': m5.large
-      '2': m5.large
+      '1': m5.xlarge
+      '2': m5.xlarge
       '3': m5.xlarge
       '4': m5.xlarge
   RDSStorageSize:


### PR DESCRIPTION
*Description of changes:*

1. Upgrading the version of DSM to 20.0.174
2. Enhance the proxy url allowed pattern regex
3. Add new supported instance type of DSM node
> m4.4xlarge
> m4.10xlarge
> m5.4xlarge
> m5.8xlarge
> c5.4xlarge
> c5.9xlarge
4. Run instance with IMDS v2
> Use AWS::EC2::LaunchTemplate to always deploy IMDS V2 required instances as DSM node


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
